### PR TITLE
[master] Fix extra whitespaces rendered by `head :ok`

### DIFF
--- a/app/controllers/s3_objects_controller.rb
+++ b/app/controllers/s3_objects_controller.rb
@@ -100,7 +100,7 @@ class S3ObjectsController < ApplicationController
     response.headers.tap do |hs|
       hs['ETag'] = @s3_object.md5
     end
-    head :ok
+    render plain: '', status: :ok
   end
 
   def copy


### PR DESCRIPTION
These whitespaces breaks the ruby aws sdk v2 behavior